### PR TITLE
[GATE 1775] User agent

### DIFF
--- a/vivialconnect/common/requestor.py
+++ b/vivialconnect/common/requestor.py
@@ -257,8 +257,7 @@ class Requestor(object):
             'request_lib': 'requests',
         }
         for attr, func in [['lang_version', platform.python_version],
-                           ['platform', platform.platform],
-                           ['uname', lambda: ' '.join(platform.uname())]]:
+                           ['platform', platform.platform]]:
             try:
                 val = func()
             except Exception as e:
@@ -268,7 +267,7 @@ class Requestor(object):
         parsed_url = urlparse(abs_url)
         headers = {
             'X-VivialConnect-User-Agent': json.dumps(ua),
-            'User-Agent': 'VivialConnect PythonClient/%s' % VERSION,
+            'User-Agent': 'VivialConnect PythonClient %s' % VERSION,
             'Date': '%s' % (now.strftime("%a, %d %b %Y %H:%M:%S GMT")),
             'Host': parsed_url.hostname + ((':' + str(parsed_url.port)) if parsed_url.port else ''),
             'Accept': API_CONTENT_TYPE


### PR DESCRIPTION
Not many changes to make in this library, just removing the user's machine name and standardizing the user agent formatting.

Example HTTP headers:
```
{'Accept': 'application/json',
 'Authorization': 'HMAC MTK4AHJ1NB8QBEPPRAKKDJ9AK2L0Z5GBPOU:a69be05a8445da0469e28e971272e67232bcb15be4f4b102a07fa7f6222de4b9',
 'Date': 'Mon, 04 Dec 2017 20:54:15 GMT',
 'Host': 'api-stage-8c935d.moosetalk.net',
 'User-Agent': 'VivialConnect PythonClient 0.1.10',
 'X-Auth-Date': '20171204T205415Z',
 'X-Auth-SignedHeaders': 'date;host',
 'X-VivialConnect-User-Agent': {'client_version': '0.1.10',
                                'lang': 'python',
                                'lang_version': '3.5.2',
                                'platform': 'Linux-4.10.0-40-generic-x86_64-with-Ubuntu-16.04-xenial',
                                'publisher': 'vivialconnect',
                                'request_lib': 'requests'}}
```